### PR TITLE
Add overview and cases pages with navigation

### DIFF
--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,0 +1,22 @@
+import { CaseCard } from "@/components/CaseCard";
+import { cases } from "@/data/mockCases";
+
+export default function CasesPage() {
+  return (
+    <div className="space-y-6">
+      <section className="bg-lime-50 rounded-xl p-4 text-center">
+        🌿 Today’s notes: Sun is shining, plots are growing fast. Let’s review
+        concerns with patience and care.
+      </section>
+      <section className="flex items-center justify-between">
+        <h1 className="text-3xl font-serif">Open Cases</h1>
+        <span className="text-sm text-muted-foreground">Filters coming soon</span>
+      </section>
+      <div className="grid gap-6 sm:grid-cols-2">
+        {cases.map((c) => (
+          <CaseCard key={c.id} {...c} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/guidelines/page.tsx
+++ b/src/app/guidelines/page.tsx
@@ -1,0 +1,8 @@
+export default function GuidelinesPage() {
+  return (
+    <div className="space-y-4 py-16 text-center">
+      <h1 className="text-3xl font-serif">Community Guidelines</h1>
+      <p className="text-muted-foreground">We'll grow this section soon.</p>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -18,6 +19,24 @@ export default function RootLayout({
             "radial-gradient(circle at top left, #D4EAC8 0%, #F9F9F6 80%)",
         }}
       >
+        <header className="bg-white/60 backdrop-blur-md">
+          <nav className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
+            <Link href="/" className="font-serif text-2xl text-olive">
+              Garden Gate
+            </Link>
+            <div className="flex gap-4 text-sm">
+              <Link href="/overview" className="hover:underline">
+                Overview
+              </Link>
+              <Link href="/cases" className="hover:underline">
+                Cases
+              </Link>
+              <Link href="/guidelines" className="hover:underline">
+                Guidelines
+              </Link>
+            </div>
+          </nav>
+        </header>
         <main className="px-4 py-8 max-w-4xl mx-auto">{children}</main>
       </body>
     </html>

--- a/src/app/overview/page.tsx
+++ b/src/app/overview/page.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { cases } from "@/data/mockCases";
+
+export default function OverviewPage() {
+  const openItems = cases.length;
+  return (
+    <div className="text-center space-y-8 py-16">
+      <div className="text-6xl">🌿</div>
+      <h1 className="text-3xl font-serif">Welcome back.</h1>
+      <p className="text-lg text-muted-foreground">
+        You have {openItems} open items to review today.
+      </p>
+      <Link
+        href="/cases"
+        className="inline-block bg-softGreen text-olive px-4 py-2 rounded-md hover:bg-softGreen/80"
+      >
+        View Cases
+      </Link>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,52 +1,5 @@
-import { CaseCard } from "@/components/CaseCard";
-import { cases } from "@/data/mockCases";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <div
-      className="min-h-screen"
-      style={{
-        background: "radial-gradient(circle at top, #D4EAC8 0%, #F9F9F6 80%)",
-      }}
-    >
-      <header className="text-center space-y-4 py-10">
-        <svg
-          width="40"
-          height="40"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="mx-auto text-softGreen"
-        >
-          <path
-            d="M12 22s8-4 8-12V5.5c0-.83-.67-1.5-1.5-1.5h-1C15 4 12 6 12 10"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M12 22S4 18 4 10V5.5C4 4.67 4.67 4 5.5 4h1C9 4 12 6 12 10"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        <h1 className="text-5xl">Garden Gate</h1>
-        <p className="text-lg text-muted-foreground">
-          Where we tend to our garden — and our neighbors — with care.
-        </p>
-      </header>
-      <div className="bg-lime-50 rounded-xl p-4 mb-8 text-center">
-        🌿 Today’s notes: Sun is shining, plots are growing fast. Let’s review
-        concerns with patience and care.
-      </div>
-      <div className="grid gap-6 sm:grid-cols-2">
-        {cases.map((c) => (
-          <CaseCard key={c.id} {...c} />
-        ))}
-      </div>
-    </div>
-  );
+  redirect("/overview");
 }

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -4,6 +4,7 @@ import {
   CardHeader,
   CardTitle,
   CardDescription,
+  CardFooter,
 } from "@/components/ui/card";
 
 interface CaseCardProps {
@@ -21,40 +22,34 @@ export function CaseCard({
   severity,
   nudges,
 }: CaseCardProps) {
-  const severityIcon =
-    severity === "low" ? "🌱" : severity === "medium" ? "🧹" : "⚠️";
-
   const friendly = (n: string) => {
     if (n.toLowerCase() === "remind guidelines") return "Gently revisit rules";
     return n;
   };
 
   return (
-    <Card className="bg-white/70 backdrop-blur-sm shadow-[0_2px_8px_rgba(0,0,0,0.05)] hover:scale-[1.01] transition-transform text-foreground">
-      <CardHeader className="flex items-start gap-3">
-        <span className="text-2xl" aria-hidden="true">
-          {severityIcon}
-        </span>
-        <div>
-          <CardTitle className="text-xl">{memberName}</CardTitle>
-          <CardDescription className="text-sm">
-            {new Date(date).toLocaleDateString()}
-          </CardDescription>
-        </div>
+    <Card className="border-l-4 border-lime-400 bg-white/70 backdrop-blur-sm shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg font-semibold">{memberName}</CardTitle>
+        <CardDescription className="text-xs text-zinc-500">
+          {new Date(date).toLocaleDateString()}
+        </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-2">
+      <CardContent className="py-2">
         <p>{incident}</p>
-        <div className="flex flex-wrap gap-2">
-          {nudges.map((nudge, idx) => (
-            <span
-              key={idx}
-              className="bg-softGreen text-olive/90 px-2 py-1 rounded-full text-xs"
-            >
-              {friendly(nudge)}
-            </span>
-          ))}
-        </div>
       </CardContent>
+      <CardFooter className="flex-col items-stretch">
+        <div className="w-full rounded-md border bg-zinc-50 p-3">
+          <p className="mb-1 text-xs font-medium">Suggested Actions</p>
+          <ul className="list-disc space-y-1 pl-4">
+            {nudges.map((nudge, idx) => (
+              <li key={idx} className="text-xs">
+                {friendly(nudge)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </CardFooter>
     </Card>
   );
 }

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -19,7 +19,6 @@ export function CaseCard({
   memberName,
   incident,
   date,
-  severity,
   nudges,
 }: CaseCardProps) {
   const friendly = (n: string) => {
@@ -28,7 +27,7 @@ export function CaseCard({
   };
 
   return (
-    <Card className="border-l-4 border-lime-400 bg-white/70 backdrop-blur-sm shadow-sm">
+    <Card className="gap-0 border-l-4 border-lime-400 bg-white/70 backdrop-blur-sm shadow-sm">
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold">{memberName}</CardTitle>
         <CardDescription className="text-xs text-zinc-500">


### PR DESCRIPTION
## Summary
- add persistent navigation header in layout
- create friendly overview page with link to cases
- move case list to `/cases` with filters placeholder
- redirect `/` to `/overview`
- add placeholder guidelines page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acf40104c832495e6f50fdaf187be