### PR TITLE
Refine modal and card styling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,11 +13,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className="min-h-screen bg-gardenStone text-zinc-700"
-        style={{
-          background:
-            "radial-gradient(circle at top left, #406C2C 0%, #D4EAC8 80%)",
-        }}
+        className="min-h-screen bg-gradient-to-b from-stone-100 via-lime-50 to-stone-100 text-zinc-700"
       >
         <header className="bg-white/60 backdrop-blur-md">
           <nav className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -35,16 +35,16 @@ export function CaseCard({
     incident.length > 80 ? `${incident.slice(0, 80)}…` : incident;
 
   const severityStyles: Record<CaseCardProps["severity"], string> = {
-    low: "bg-lime-100 text-lime-800",
-    medium: "bg-yellow-100 text-yellow-800",
-    high: "bg-red-100 text-red-800",
+    low: "bg-lime-100 text-lime-700",
+    medium: "bg-amber-100 text-amber-700",
+    high: "bg-rose-100 text-rose-700",
   };
 
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Card className="cursor-pointer overflow-hidden">
-          <CardHeader className="pb-2">
+        <Card className="cursor-pointer overflow-hidden transition-colors hover:bg-stone-50 hover:shadow-md">
+          <CardHeader className="pb-1">
             <div className="flex items-center justify-between">
               <CardTitle className="text-lg font-semibold">
                 {memberName}
@@ -56,34 +56,34 @@ export function CaseCard({
               </span>
             </div>
           </CardHeader>
-          <CardContent className="pt-0 pb-2">
+          <CardContent className="pt-0 pb-1">
             <p className="text-sm line-clamp-2">{truncated}</p>
           </CardContent>
           {nudge && (
-            <CardFooter className="pt-2">
-              <div className="w-full rounded bg-zinc-100 px-2 py-1 text-xs text-zinc-600">
+            <CardFooter className="pt-1">
+              <div className="w-full rounded bg-stone-100 px-3 py-2 text-sm text-zinc-700">
                 Suggested Action: {nudge}
               </div>
             </CardFooter>
           )}
         </Card>
       </DialogTrigger>
-      <DialogContent className="space-y-4">
+      <DialogContent className="space-y-4 rounded-xl bg-stone-50 p-6 text-zinc-700 shadow-xl">
         <DialogHeader>
-          <DialogTitle>{memberName}</DialogTitle>
+          <DialogTitle className="text-lg font-semibold text-darkGarden">{memberName}</DialogTitle>
         </DialogHeader>
         <p>{incident}</p>
         <p className="text-sm">Repeat offense: {repeatOffense ? "Yes" : "No"}</p>
         {nudge && (
-          <div className="rounded bg-zinc-100 p-3 text-sm text-zinc-700">
+          <div className="rounded-md bg-lime-100 p-2 text-sm text-darkGarden">
             Suggested Action: {nudge}
           </div>
         )}
         <DialogFooterRoot>
           <DialogClose asChild>
-            <button className="rounded border px-3 py-1 text-sm">Close</button>
+            <button className="rounded-md border border-zinc-300 bg-white px-4 py-1.5 text-sm text-zinc-600 hover:bg-zinc-100">Close</button>
           </DialogClose>
-          <button className="rounded bg-red-600 px-3 py-1 text-sm text-white">
+          <button className="rounded-md bg-rose-600 px-4 py-1.5 text-sm text-white hover:bg-rose-700">
             Escalate
           </button>
         </DialogFooterRoot>


### PR DESCRIPTION
## Summary
- smooth out background gradient
- restyle case cards with softer severity colors and nudge bar
- redesign dialog contents and buttons for clearer tone

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686add8a1ce88324bdbc18910ef56f29